### PR TITLE
feat(cli): add Jira ticket option to generate commit command 

### DIFF
--- a/handy_utils/cli.py
+++ b/handy_utils/cli.py
@@ -12,11 +12,15 @@ def main():
 
 
 @click.command("generate-commit")
+@click.option("--jira-ticket", type=str, help="Jira ticket number.")
 @click.option("--dry-run", is_flag=True, help="Dry run the commit generation.")
-def generate_commit_command(dry_run):
+def generate_commit_command(jira_ticket: str, dry_run: bool):
     """Generate a commit message for the changes."""
-    commit_message = generate_llm_commit_message()
+    commit_message = generate_llm_commit_message(jira_ticket)
     click.echo(commit_message)
+    if dry_run:
+        click.echo("Dry run completed.")
+        return
     k = click.prompt("confirm commit message (y/n) or edit (e)", type=click.Choice(['y', 'n', 'e']))
     if k == 'y':
         perform_commit(commit_message)

--- a/handy_utils/generate_commit/__init__.py
+++ b/handy_utils/generate_commit/__init__.py
@@ -1,0 +1,3 @@
+from handy_utils.generate_commit.generate_commit import generate_llm_commit_message, perform_commit
+
+__all__ = ["generate_llm_commit_message", "perform_commit"]

--- a/handy_utils/generate_commit/generate_commit.py
+++ b/handy_utils/generate_commit/generate_commit.py
@@ -4,24 +4,25 @@ import subprocess
 from langchain_core.prompts import PromptTemplate
 
 from handy_utils.configuration import load_configuration, load_llm
-
+from handy_utils.generate_commit.prompts import CONVENTIONAL_COMMIT_SPEC, PROMPT, ADDITIONAL_JIRA_TICKET_PROMPT
 
 def get_changes():
     """Get the changes to be committed."""
     return subprocess.check_output(["git", "diff", "--cached"]).decode("utf-8")
 
 
-def generate_llm_commit_message():
+def generate_llm_commit_message(jira_ticket: str|None = None) -> str:
     """Generate a commit message for the changes."""
     config = load_configuration()
     llm = load_llm(config)
     changes = get_changes()
-    prompt = PromptTemplate.from_template("Generate a commit message for the following changes: {changes}")
-    chain = prompt | llm
+    prompt = PROMPT if jira_ticket is None else PROMPT + ADDITIONAL_JIRA_TICKET_PROMPT
+    prompt_tpl = PromptTemplate.from_template(template=prompt)
+    chain = prompt_tpl | llm
     assert changes, "No changes to commit"
-    commit_message = chain.invoke({"changes": changes}).content
+    commit_message = chain.invoke({"changes": changes, "jira_ticket": jira_ticket, "conventional_commit_spec": CONVENTIONAL_COMMIT_SPEC}).content
+    assert isinstance(commit_message, str), "Commit message is not a string"
     return commit_message
-
 
 def perform_commit(commit_message):
     """Perform the commit."""

--- a/handy_utils/generate_commit/prompts.py
+++ b/handy_utils/generate_commit/prompts.py
@@ -1,0 +1,34 @@
+CONVENTIONAL_COMMIT_SPEC = """
+The key words “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL NOT”, “SHOULD”, “SHOULD NOT”, “RECOMMENDED”, “MAY”, and “OPTIONAL” in this document are to be interpreted as described in RFC 2119.
+
+1. Commits MUST be prefixed with a type, which consists of a noun, feat, fix, etc., followed by the OPTIONAL scope, OPTIONAL !, and REQUIRED terminal colon and space.
+2. The type feat MUST be used when a commit adds a new feature to your application or library.
+3. The type fix MUST be used when a commit represents a bug fix for your application.
+4. A scope MAY be provided after a type. A scope MUST consist of a noun describing a section of the codebase surrounded by parenthesis, e.g., fix(parser):
+5. A description MUST immediately follow the colon and space after the type/scope prefix. The description is a short summary of the code changes, e.g., fix: array parsing issue when multiple spaces were contained in string.
+6. A longer commit body MAY be provided after the short description, providing additional contextual information about the code changes. The body MUST begin one blank line after the description.
+7. A commit body is free-form and MAY consist of any number of newline separated paragraphs.
+8. One or more footers MAY be provided one blank line after the body. Each footer MUST consist of a word token, followed by either a :<space> or <space># separator, followed by a string value (this is inspired by the git trailer convention).
+9. A footer's token MUST use - in place of whitespace characters, e.g., Acked-by (this helps differentiate the footer section from a multi-paragraph body). An exception is made for BREAKING CHANGE, which MAY also be used as a token.
+10. A footer's value MAY contain spaces and newlines, and parsing MUST terminate when the next valid footer token/separator pair is observed.
+11. Breaking changes MUST be indicated in the type/scope prefix of a commit, or as an entry in the footer.
+12. If included as a footer, a breaking change MUST consist of the uppercase text BREAKING CHANGE, followed by a colon, space, and description, e.g., BREAKING CHANGE: environment variables now take precedence over config files.
+13. If included in the type/scope prefix, breaking changes MUST be indicated by a ! immediately before the :. If ! is used, BREAKING CHANGE: MAY be omitted from the footer section, and the commit description SHALL be used to describe the breaking change.
+14. Types other than feat and fix MAY be used in your commit messages, e.g., docs: update ref docs.
+15. The units of information that make up Conventional Commits MUST NOT be treated as case sensitive by implementors, with the exception of BREAKING CHANGE which MUST be uppercase.
+16. BREAKING-CHANGE MUST be synonymous with BREAKING CHANGE, when used as a token in a footer.
+"""
+
+PROMPT = """
+You are a git commit message generator. Generate a commit message for the changes given below. 
+Note that the changes should follow the conventional commits specification.
+Changes: 
+```diff
+{changes}
+```
+Conventional commits specification: 
+{conventional_commit_spec}
+"""
+
+ADDITIONAL_JIRA_TICKET_PROMPT = """Here is the additional information for the Jira ticket: {jira_ticket}. Incorporate this information into the commit message as part of the scope.
+"""


### PR DESCRIPTION
- Introduced a new `--jira-ticket` option to the `generate-commit` command in `cli.py` to include Jira ticket information in commit messages.
- Updated `generate_llm_commit_message` to accept an optional `jira_ticket` parameter and adjust the prompt accordingly.
- Added a new module `generate_commit` with `__init__.py` to export `generate_llm_commit_message` and `perform_commit`.
- Moved `generate_commit.py` to `generate_commit/generate_commit.py` and updated imports.
- Created `prompts.py` to store prompt templates and the conventional commit specification.

This enhancement allows users to incorporate Jira ticket information into commit messages, improving traceability and context.